### PR TITLE
customize bottom sheet with rounded style

### DIFF
--- a/app/src/main/java/com/commit451/modalbottomsheetdialogfragment/sample/MainActivity.kt
+++ b/app/src/main/java/com/commit451/modalbottomsheetdialogfragment/sample/MainActivity.kt
@@ -47,6 +47,15 @@ class MainActivity : AppCompatActivity(), ModalBottomSheetDialogFragment.Listene
                     .add(R.menu.option_money)
                     .show(supportFragmentManager, "HI")
         }
+
+        binding.buttonRounded.setOnClickListener {
+            ModalBottomSheetDialogFragment.Builder()
+                .add(R.menu.options)
+                .add(OptionRequest(123, "Custom", R.drawable.ic_bluetooth_black_24dp))
+                .add(R.menu.option_money)
+                .rounded(true)
+                .show(supportFragmentManager, "HI")
+        }
     }
 
     override fun onModalOptionSelected(tag: String?, option: Option) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -40,4 +40,12 @@
         android:layout_margin="8dp"
         android:text="Show Retains Order" />
 
+    <Button
+        android:id="@+id/buttonRounded"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="8dp"
+        android:text="Show Rounded" />
+
 </LinearLayout>

--- a/modalbottomsheetdialogfragment/src/main/java/com/commit451/modalbottomsheetdialogfragment/ModalBottomSheetDialogFragment.kt
+++ b/modalbottomsheetdialogfragment/src/main/java/com/commit451/modalbottomsheetdialogfragment/ModalBottomSheetDialogFragment.kt
@@ -32,6 +32,7 @@ class ModalBottomSheetDialogFragment : BottomSheetDialogFragment() {
         private const val KEY_COLUMNS = "columns"
         private const val KEY_HEADER = "header"
         private const val KEY_HEADER_LAYOUT_RES = "header_layout_res"
+        private const val KEY_ROUNDED = "rounded"
 
         private fun newInstance(builder: Builder): ModalBottomSheetDialogFragment {
             val fragment = ModalBottomSheetDialogFragment()
@@ -41,6 +42,7 @@ class ModalBottomSheetDialogFragment : BottomSheetDialogFragment() {
             args.putInt(KEY_COLUMNS, builder.columns)
             args.putString(KEY_HEADER, builder.header)
             args.putInt(KEY_HEADER_LAYOUT_RES, builder.headerLayoutRes)
+            args.putBoolean(KEY_ROUNDED, builder.isRounded)
             fragment.arguments = args
             return fragment
         }
@@ -56,6 +58,16 @@ class ModalBottomSheetDialogFragment : BottomSheetDialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.modal_bottom_sheet_dialog_fragment, container, false)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val arguments = arguments
+            ?: throw IllegalStateException("You need to create this via the builder")
+        val isRounded = arguments.getBoolean(KEY_ROUNDED)
+        if (isRounded){
+            setStyle(STYLE_NORMAL, R.style.RoundedBottomSheetDialogTheme)
+        }
     }
 
     @SuppressLint("RestrictedApi")
@@ -143,6 +155,7 @@ class ModalBottomSheetDialogFragment : BottomSheetDialogFragment() {
         internal var columns = 1
         internal var header: String? = null
         internal var headerLayoutRes = R.layout.modal_bottom_sheet_dialog_fragment_header
+        internal var isRounded = false
 
         /**
          * Inflate the given menu resource to the options
@@ -184,6 +197,14 @@ class ModalBottomSheetDialogFragment : BottomSheetDialogFragment() {
         fun header(header: String, @LayoutRes layoutRes: Int = R.layout.modal_bottom_sheet_dialog_fragment_header): Builder {
             this.header = header
             this.headerLayoutRes = layoutRes
+            return this
+        }
+
+        /*
+        * Set rounded on top bottom sheet dialog
+        */
+        fun rounded(isRounded: Boolean): Builder{
+            this.isRounded = isRounded
             return this
         }
 

--- a/modalbottomsheetdialogfragment/src/main/res/drawable/rounded.xml
+++ b/modalbottomsheetdialogfragment/src/main/res/drawable/rounded.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:topLeftRadius="16dp"
+        android:topRightRadius="16dp"/>
+    <solid android:color="@android:color/white"/>
+
+</shape>

--- a/modalbottomsheetdialogfragment/src/main/res/values/styles.xml
+++ b/modalbottomsheetdialogfragment/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="RoundedBottomSheetDialogTheme"
+        parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/RedoundedModalStyle</item>
+    </style>
+
+    <style name="RedoundedModalStyle" parent="Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/rounded</item>
+    </style>
+</resources>


### PR DESCRIPTION
added a bottom sheet customization with a rounded style at the top. The following is an example of its use::

```kotlin
  ModalBottomSheetDialogFragment.Builder()
      .add(R.menu.options)
      .add(OptionRequest(123, "Custom", R.drawable.ic_bluetooth_black_24dp))
      .add(R.menu.option_money)
      .rounded(true)
      .show(supportFragmentManager, "HI")
```

output
![Screenshot_20220618_221121](https://user-images.githubusercontent.com/43547226/174444714-3b9b8d41-f75a-4e74-a60d-1762ff2d25af.png)

